### PR TITLE
Sequential probabilistic changes

### DIFF
--- a/test/test_cost.py
+++ b/test/test_cost.py
@@ -2921,6 +2921,8 @@ def test_shared_params(dest, expected_dtype, expected_device):
         loss.qvalue_network_params.items(include_nested=True, leaves_only=True)
     ):
         p1 = value
+        if isinstance(loss.actor_network, SafeProbabilisticModule):
+            key = ("module", *key) if isinstance(key, tuple) else ("module", key)
         p2 = loss.actor_network_params[key]
         assert (p1 == p2).all()
         if i == 1:
@@ -2943,6 +2945,8 @@ def test_shared_params(dest, expected_dtype, expected_device):
     for i, (key, qvalparam) in enumerate(
         loss.qvalue_network_params.items(include_nested=True, leaves_only=True)
     ):
+        if isinstance(loss.actor_network, SafeProbabilisticModule):
+            key = ("module", *key) if isinstance(key, tuple) else ("module", key)
         assert qvalparam.dtype is expected_dtype, (key, qvalparam)
         assert qvalparam.device == torch.device(expected_device), key
         assert (qvalparam == loss.actor_network_params[key]).all(), key

--- a/torchrl/modules/tensordict_module/actors.py
+++ b/torchrl/modules/tensordict_module/actors.py
@@ -650,8 +650,22 @@ class ActorValueOperator(SafeSequential):
             value_operator,
         )
 
-    def get_policy_operator(self) -> SafeSequential:
+    def get_policy_operator(self) -> SafeModule:
         """Returns a stand-alone policy operator that maps an observation to an action."""
+        if isinstance(self.module[1], SafeProbabilisticModule):
+            return SafeProbabilisticModule(
+                SafeSequential(self.module[0], self.module[1].module),
+                dist_in_keys=self.module[1].dist_in_keys,
+                sample_out_key=self.module[1].sample_out_key,
+                spec=self.module[1].spec,
+                safe=self.module[1].safe,
+                default_interaction_mode=self.module[1].default_interaction_mode,
+                distribution_class=self.module[1].distribution_class,
+                distribution_kwargs=self.module[1].distribution_kwargs,
+                return_log_prob=self.module[1].return_log_prob,
+                cache_dist=self.module[1].cache_dist,
+                n_empirical_estimate=self.module[1].n_empirical_estimate,
+            )
         return SafeSequential(self.module[0], self.module[1])
 
     def get_value_operator(self) -> SafeSequential:

--- a/torchrl/objectives/redq.py
+++ b/torchrl/objectives/redq.py
@@ -10,7 +10,6 @@ from typing import Union
 import numpy as np
 import torch
 
-from tensordict.nn import TensorDictSequential
 from tensordict.tensordict import TensorDict, TensorDictBase
 from torch import Tensor
 
@@ -191,16 +190,9 @@ class REDQLoss(LossModule):
                 tensordict_actor,
                 actor_params,
             )
-            if isinstance(self.actor_network, TensorDictSequential):
-                sample_key = self.actor_network[-1].sample_out_key[0]
-                tensordict_actor_dist = self.actor_network[-1].build_dist_from_params(
-                    td_params
-                )
-            else:
-                sample_key = self.actor_network.sample_out_key[0]
-                tensordict_actor_dist = self.actor_network.build_dist_from_params(
-                    td_params
-                )
+
+            sample_key = self.actor_network.sample_out_key[0]
+            tensordict_actor_dist = self.actor_network.build_dist_from_params(td_params)
             tensordict_actor[sample_key] = tensordict_actor_dist.rsample()
             tensordict_actor["sample_log_prob"] = tensordict_actor_dist.log_prob(
                 tensordict_actor[sample_key]


### PR DESCRIPTION
## Description

pytorch-labs/tensordict#88 deprecates the `get_dist` and `get_dist_params` methods of `TensorDictSequential` and hence `torchrl.modules.SafeSequential` which subclasses it. This PR adapts code and tests in TorchRL for that change.